### PR TITLE
Add RFC 3986 in field type template encoding

### DIFF
--- a/classes/class.ilExternalContentEncodings.php
+++ b/classes/class.ilExternalContentEncodings.php
@@ -17,6 +17,7 @@ class ilExternalContentEncodings
 		'',
 		'plain',
 		'url',
+		'url_rfc3986',
 		'base64',
 		'dechex',
 		'md5',
@@ -107,7 +108,11 @@ class ilExternalContentEncodings
 	            case 'url':
 	                $value = urlencode($value);
 	                break;
-	
+
+	            case 'url_rfc3986':
+	                $value = rawurlencode($value);
+	                break;
+
 	            case 'md5':
 	                $value = md5($value);
 	                break;


### PR DESCRIPTION
`urlencode()` encodes spaces to "+".

This might be unwanted in some situations, for instance when creating email links (mailto: scheme).

I am aware of the extension possibilities in `Customizing/global/encodings/class.ilMyEncoding.php` however, I'd try to keep customizations as small as possible. So checking here if people/maintainer would merge or reject. Thanks.